### PR TITLE
Added DSC definitions + info to main page

### DIFF
--- a/src/WinGetStudio/Strings/en-us/Resources.resw
+++ b/src/WinGetStudio/Strings/en-us/Resources.resw
@@ -540,4 +540,34 @@
   <data name="Notification_MachineNotInDesiredState" xml:space="preserve">
     <value>Machine is not in the desired state</value>
   </data>
+  <data name="MainPage_Definitions.Header" xml:space="preserve">
+    <value>WinGet &amp; DSC Definitions</value>
+  </data>
+  <data name="MainPage_Content.Text" xml:space="preserve">
+    <value>Get Started with Winget Studio</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_ConfigurationFile.Text" xml:space="preserve">
+    <value>What is a "configuration file"?</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_ConfigurationFileDesc.Text" xml:space="preserve">
+    <value>A configuration file is a YAML document that describes the desired state of a system. It contains one or more resources that define how applications, settings, and system components should be configured.</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_Resource.Text" xml:space="preserve">
+    <value>What is a "resource"?</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_ResourceDesc.Text" xml:space="preserve">
+    <value>A resource represents a single unit of configuration, such as installing an application, creating a registry key, or configuring a system setting. Each resource specifies what should be configured and how.</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_Property.Text" xml:space="preserve">
+    <value>What is a "property"?</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_PropertyDesc.Text" xml:space="preserve">
+    <value>A property is a specific setting or parameter within a resource that defines how that resource should behave. Properties include values like file paths, registry values, application IDs, and other configuration details.</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_Module.Text" xml:space="preserve">
+    <value>What is a "module"?</value>
+  </data>
+  <data name="MainPage_DSCDefinitions_ModuleDesc.Text" xml:space="preserve">
+    <value>A module is a PowerShell module that contains the implementation for one or more DSC resources. Modules provide the actual functionality to apply configurations, such as the Microsoft.WinGet.DSC module for package management.</value>
+  </data>
 </root>

--- a/src/WinGetStudio/Views/MainPage.xaml
+++ b/src/WinGetStudio/Views/MainPage.xaml
@@ -8,22 +8,124 @@
     xmlns:helpers="using:WinGetStudio.Helpers"
     mc:Ignorable="d">
 
-    <Grid x:Name="ContentArea" VerticalAlignment="Top">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
-        <ct:SettingsCard
-            Command="{x:Bind ViewModel.NavigateToConfigurationCommand}"
-            x:Uid="MainPage_ManageCard"
-            IsClickEnabled="True"
-            Grid.Column="0"/>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="24" Margin="24">
+            <TextBlock x:Uid="MainPage_Content"
+                       Style="{ThemeResource HeaderTextBlockStyle}" />
+            <!-- Main Actions -->
+            <Grid x:Name="ContentArea">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <ct:SettingsCard
+                    Command="{x:Bind ViewModel.NavigateToConfigurationCommand}"
+                    x:Uid="MainPage_ManageCard"
+                    IsClickEnabled="True"
+                    Grid.Column="0"/>
 
-        <ct:SettingsCard
-            Command="{x:Bind ViewModel.NavigateToValidationCommand}"
-            x:Uid="MainPage_ValidateCard"
-            IsClickEnabled="True"
-            Grid.Column="1"/>
-    </Grid>
+                <ct:SettingsCard
+                    Command="{x:Bind ViewModel.NavigateToValidationCommand}"
+                    x:Uid="MainPage_ValidateCard"
+                    IsClickEnabled="True"
+                    Grid.Column="1"/>
+            </Grid>
+
+            <!-- DSC Definitions Section -->
+            <Border Background="{ThemeResource LayerFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                <Expander x:Uid="MainPage_Definitions"
+                          IsExpanded="False"
+                          HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch">
+                    <Expander.HeaderTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <FontIcon Grid.Column="0" 
+                                          FontFamily="{StaticResource SymbolThemeFontFamily}" 
+                                          Glyph="&#xE946;" 
+                                          Margin="0,0,12,0"
+                                          VerticalAlignment="Center"
+                                          Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                <TextBlock Grid.Column="1" 
+                                           Text="{Binding}" 
+                                           Style="{ThemeResource BaseTextBlockStyle}"
+                                           VerticalAlignment="Center" />
+                            </Grid>
+                        </DataTemplate>
+                    </Expander.HeaderTemplate>
+                    <StackPanel Spacing="16" Padding="16">
+                        
+                        <!-- Configuration File Definition -->
+                        <Border Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                CornerRadius="6"
+                                Padding="16">
+                            <StackPanel Spacing="8">
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_ConfigurationFile" 
+                                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_ConfigurationFileDesc"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Style="{ThemeResource BodyTextBlockStyle}" />
+                            </StackPanel>
+                        </Border>
+                        
+                        <!-- Resource Definition -->
+                        <Border Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                CornerRadius="6"
+                                Padding="16">
+                            <StackPanel Spacing="8">
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_Resource" 
+                                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_ResourceDesc"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Style="{ThemeResource BodyTextBlockStyle}" />
+                            </StackPanel>
+                        </Border>
+                        
+                        <!-- Property Definition -->
+                        <Border Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                CornerRadius="6"
+                                Padding="16">
+                            <StackPanel Spacing="8">
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_Property" 
+                                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_PropertyDesc"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Style="{ThemeResource BodyTextBlockStyle}" />
+                            </StackPanel>
+                        </Border>
+                        
+                        <!-- Module Definition -->
+                        <Border Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                CornerRadius="6"
+                                Padding="16">
+                            <StackPanel Spacing="8">
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_Module" 
+                                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                           Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                <TextBlock x:Uid="MainPage_DSCDefinitions_ModuleDesc"
+                                           TextWrapping="Wrap"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Style="{ThemeResource BodyTextBlockStyle}" />
+                            </StackPanel>
+                        </Border>
+                        
+                    </StackPanel>
+                </Expander>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
 </Page>


### PR DESCRIPTION
## 📖 Description
Added home page title + expander for viewing common WinGet + DSC definitions

This gives more context about the tool to users that are new to WinGet and DSC.

Collapsed:
<img width="1198" height="860" alt="image" src="https://github.com/user-attachments/assets/787cfe5a-b0e9-4b0d-9c35-7aa23ed9410c" />

Expanded:
<img width="1232" height="1012" alt="image" src="https://github.com/user-attachments/assets/ca9cc28e-2dfa-4ed9-a0c7-9081736432d6" />


## ✅ Checklist
- [x] Closes #86 
