### PR TITLE
Enable YAML syntax highlighting for .winget files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -72,3 +72,6 @@
 *.7z             binary
 *.tar            binary
 *.gz             binary
+
+# GitHub Linguist
+*.winget         linguist-language=yaml


### PR DESCRIPTION
## 📖 Description

`*.winget` files are not syntax highlighted by GitHub Linguist checker. We can override the behavior on the repository level by modifying the `.gitattributes` file. See https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#using-gitattributes. This will show YAML syntax highlighting for anyone browsing the `.winget` files in this repository.

## 🔗 References and Related Issues

See related PRs:

- https://github.com/microsoft/winget-dsc/pull/175 (PR on winget-dsc repo for doing the same)
- Linguist repo PR for syntax highlighting .winget files across all of GitHub: https://github.com/github-linguist/linguist/pull/7309

## 🔍 How to Test

View the configuration.winget file in the main branch:

https://github.com/microsoft/winget-studio/blob/main/.config/configuration.winget

Screenshot

<img width="1463" height="852" alt="image" src="https://github.com/user-attachments/assets/99d97910-daf9-4e6d-b9d4-de3d2a704e95" />


and then in my branch in a SEPARATE TAB or browser or private mode (to avoid caching of GitHub)

https://github.com/mdanish-kh/winget-studio/blob/linguist-language/.config/configuration.winget


Screenshot

<img width="1501" height="861" alt="image" src="https://github.com/user-attachments/assets/dfe52b39-497d-4c21-9c7d-622ea8ca56f4" />


## ✅ Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
