### PR TITLE
Add functionality to update configuration from code with user notific…

### DIFF
--- a/src/WinGetStudio/Strings/en-us/Resources.resw
+++ b/src/WinGetStudio/Strings/en-us/Resources.resw
@@ -566,6 +566,10 @@
   <data name="PreviewPage_FilePicker_ConfigurationFiles" xml:space="preserve">
     <value>Configuration files</value>
   </data>
+  <data name="PreviewPage_UpdateFromCodeSuccess" xml:space="preserve">
+    <value>Configuration updated successfully from code</value>
+    <comment>Notification message shown when the configuration is successfully updated from the code view</comment>
+  </data>
   <data name="ConfigurationFile_SummaryView.Content" xml:space="preserve">
     <value>Summary view</value>
     <comment>Show the summary view of the configuration file</comment>

--- a/src/WinGetStudio/ViewModels/ConfigurationFlow/PreviewFileViewModel.cs
+++ b/src/WinGetStudio/ViewModels/ConfigurationFlow/PreviewFileViewModel.cs
@@ -57,6 +57,7 @@ public partial class PreviewFileViewModel : ObservableRecipient
     public partial bool IsEditMode { get; set; }
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(UpdateFromCodeCommand))]
     public partial bool IsCodeView { get; set; }
 
     [ObservableProperty]
@@ -467,6 +468,96 @@ public partial class PreviewFileViewModel : ObservableRecipient
     {
         _logger.LogInformation($"Toggling code view to {(IsCodeView ? "ON" : "OFF")}");
     }
+
+    [RelayCommand(CanExecute = nameof(CanUpdateFromCode))]
+    private async Task OnUpdateFromCode()
+    {
+        if (!IsConfigurationLoaded || string.IsNullOrWhiteSpace(ConfigurationSet.Code))
+        {
+            return;
+        }
+
+        try
+        {
+            _ui.ShowTaskProgress();
+            _logger.LogInformation("Updating configuration from code");
+
+            // Store the currently selected unit's identifier to try to reselect it after update
+            var selectedUnitId = SelectedUnit?.Item1.Id;
+
+            // Clear selected unit temporarily
+            SelectedUnit = null;
+
+            // Create a virtual DSC file from the current code
+            var dscFile = DSCFile.CreateVirtual(ConfigurationSet.Code);
+
+            // Parse the configuration
+            var dscSet = await _dsc.OpenConfigurationSetAsync(dscFile);
+
+            // Clear existing units
+            var existingUnits = ConfigurationSet.Units.ToList();
+            foreach (var unit in existingUnits)
+            {
+                await ConfigurationSet.RemoveAsync(unit);
+            }
+
+            // Load new units from parsed configuration
+            var units = dscSet?.Units ?? [];
+            var tasks = units.Select(async unit =>
+            {
+                var vm = _unitFactory();
+                await vm.CopyFromAsync(unit);
+                return vm;
+            });
+
+            var result = await Task.WhenAll(tasks);
+            foreach (var unit in result)
+            {
+                await ConfigurationSet.AddAsync(unit);
+            }
+
+            ConfigurationSet.ResolveDependencies();
+
+            // Try to reselect the same unit if it still exists, otherwise select the first unit if in edit mode
+            if (!string.IsNullOrEmpty(selectedUnitId))
+            {
+                var unitToSelect = ConfigurationSet.Units.FirstOrDefault(u => u.Id == selectedUnitId);
+                if (unitToSelect != null)
+                {
+                    await EditUnitAsync(unitToSelect);
+                }
+                else if (IsEditMode && ConfigurationSet.Units.Count > 0)
+                {
+                    // Unit ID changed or doesn't exist, select the first unit to keep right pane open
+                    await EditUnitAsync(ConfigurationSet.Units[0]);
+                }
+            }
+            else if (IsEditMode && ConfigurationSet.Units.Count > 0)
+            {
+                // No unit was selected before, but we're in edit mode, select the first unit
+                await EditUnitAsync(ConfigurationSet.Units[0]);
+            }
+
+            _ui.ShowTimedNotification(_localizer["PreviewPage_UpdateFromCodeSuccess"], NotificationMessageSeverity.Success);
+            _logger.LogInformation("Successfully updated configuration from code");
+        }
+        catch (OpenConfigurationSetException ex)
+        {
+            _logger.LogError(ex, "Failed to parse configuration from code");
+            _ui.ShowTimedNotification(ex.GetErrorMessage(_localizer), NotificationMessageSeverity.Error);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unknown error while updating from code");
+            _ui.ShowTimedNotification(ex.Message, NotificationMessageSeverity.Error);
+        }
+        finally
+        {
+            _ui.HideTaskProgress();
+        }
+    }
+
+    private bool CanUpdateFromCode => IsConfigurationLoaded && IsCodeView && !string.IsNullOrWhiteSpace(ConfigurationSet?.Code);
 
     private async Task EditUnitAsync(UnitViewModel unit)
     {

--- a/src/WinGetStudio/Views/ConfigurationFlow/PreviewFilePage.xaml
+++ b/src/WinGetStudio/Views/ConfigurationFlow/PreviewFilePage.xaml
@@ -448,12 +448,34 @@
                             </Grid>
 
                             <!-- Code view -->
-                            <ScrollViewer Grid.Row="4"
-                                          Visibility="{x:Bind ViewModel.IsCodeView, Mode=OneWay}"
-                                          HorizontalScrollBarVisibility="Auto"
-                                          VerticalScrollBarVisibility="Auto">
-                                <localControls:MonacoEditor Text="{x:Bind ViewModel.ConfigurationSet.Code, Mode=OneWay}" Syntax="yaml" IsReadOnly="True" />
-                            </ScrollViewer>
+                            <Grid Grid.Row="4"
+                                  Visibility="{x:Bind ViewModel.IsCodeView, Mode=OneWay}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="auto" />
+                                </Grid.RowDefinitions>
+                                
+                                <!-- Monaco Editor -->
+                                <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                              VerticalScrollBarVisibility="Auto">
+                                    <localControls:MonacoEditor Text="{x:Bind ViewModel.ConfigurationSet.Code, Mode=TwoWay}" Syntax="yaml" IsReadOnly="False" />
+                                </ScrollViewer>
+                                
+                                <!-- Update button -->
+                                <StackPanel Grid.Row="1" 
+                                            Orientation="Horizontal" 
+                                            HorizontalAlignment="Right"
+                                            Spacing="8"
+                                            Margin="0,8,0,0">
+                                    <Button Command="{x:Bind ViewModel.UpdateFromCodeCommand}"
+                                            Style="{ThemeResource AccentButtonStyle}">
+                                        <StackPanel Orientation="Horizontal" Spacing="4">
+                                            <FontIcon Glyph="&#xE895;" FontSize="{ThemeResource BodyTextBlockFontSize}" />
+                                            <TextBlock>Update from Code</TextBlock>
+                                        </StackPanel>
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
                         </Grid>
 
                         <!-- Resizer -->


### PR DESCRIPTION
## 📖 Description

This PR implements an editable code view feature that enables bidirectional synchronization between the YAML code editor and the configuration items list in the Preview File page.


**User experience:**

1. The code view's Monaco editor is now editable (changed from read-only to editable mode)
2. Added an "Update from Code" button below the code editor
3. Implemented two-way data binding between the YAML code and the configuration UI

## 🔗 References and Related Issues

## 🔍 How to Test

## ✅ Checklist
- [x] Closes #155
- [ ] Tests added/passed
- [ ] Documentation updated
