### PR TITLE
Implement DSC process methods for resource management and update ValidationViewModel to utilize them

### DIFF
--- a/src/services/WinGetStudio.Services.DesiredStateConfiguration.Explorer/Contracts/IDSCProcess.cs
+++ b/src/services/WinGetStudio.Services.DesiredStateConfiguration.Explorer/Contracts/IDSCProcess.cs
@@ -6,7 +6,7 @@ using WinGetStudio.Services.DesiredStateConfiguration.Explorer.Models;
 
 namespace WinGetStudio.Services.DesiredStateConfiguration.Explorer.Contracts;
 
-internal interface IDSCProcess
+public interface IDSCProcess
 {
     /// <summary>
     /// Gets the schema for a given DSC resource.
@@ -14,4 +14,28 @@ internal interface IDSCProcess
     /// <param name="resource">The resource name.</param>
     /// <returns>The DSC process result containing the schema.</returns>
     Task<DSCProcessResult> GetResourceSchemaAsync(string resource);
+
+    /// <summary>
+    /// Gets the current state of a DSC resource.
+    /// </summary>
+    /// <param name="resource">The resource name.</param>
+    /// <param name="input">The input content (JSON or YAML) containing the resource settings.</param>
+    /// <returns>The DSC process result containing the current state.</returns>
+    Task<DSCProcessResult> GetResourceAsync(string resource, string input);
+
+    /// <summary>
+    /// Sets the state of a DSC resource to match the desired state.
+    /// </summary>
+    /// <param name="resource">The resource name.</param>
+    /// <param name="input">The input content (JSON or YAML) containing the desired state.</param>
+    /// <returns>The DSC process result containing before/after states and changed properties.</returns>
+    Task<DSCProcessResult> SetResourceAsync(string resource, string input);
+
+    /// <summary>
+    /// Tests whether a DSC resource is in the desired state.
+    /// </summary>
+    /// <param name="resource">The resource name.</param>
+    /// <param name="input">The input content (JSON or YAML) containing the desired state.</param>
+    /// <returns>The DSC process result containing the test results.</returns>
+    Task<DSCProcessResult> TestResourceAsync(string resource, string input);
 }

--- a/src/services/WinGetStudio.Services.DesiredStateConfiguration.Explorer/Models/DSCProcessResult.cs
+++ b/src/services/WinGetStudio.Services.DesiredStateConfiguration.Explorer/Models/DSCProcessResult.cs
@@ -3,7 +3,7 @@
 
 namespace WinGetStudio.Services.DesiredStateConfiguration.Explorer.Models;
 
-internal sealed partial class DSCProcessResult
+public sealed partial class DSCProcessResult
 {
     /// <summary>
     /// Gets the output from the process.

--- a/src/services/WinGetStudio.Services.DesiredStateConfiguration.Explorer/Services/DSCProcess.cs
+++ b/src/services/WinGetStudio.Services.DesiredStateConfiguration.Explorer/Services/DSCProcess.cs
@@ -28,7 +28,28 @@ internal sealed partial class DSCProcess : IDSCProcess
         // This implementation can potentially be removed once this issue is resolved:
         // https://github.com/microsoft/winget-cli/issues/5829
         _logger.LogInformation($"Getting schema for DSC resource: {resource}");
-        return Task.Run(() => ExecuteAsync("resource", "schema", "-r", resource, "-o", "json"));
+        return ExecuteAsync("resource", "schema", "-r", resource, "-o", "json");
+    }
+
+    /// <inheritdoc/>
+    public Task<DSCProcessResult> GetResourceAsync(string resource, string input)
+    {
+        _logger.LogInformation($"Getting current state for DSC resource: {resource}");
+        return ExecuteAsync("resource", "get", "--resource", resource, "--input", input, "--output-format", "yaml");
+    }
+
+    /// <inheritdoc/>
+    public Task<DSCProcessResult> SetResourceAsync(string resource, string input)
+    {
+        _logger.LogInformation($"Setting state for DSC resource: {resource}");
+        return ExecuteAsync("resource", "set", "--resource", resource, "--input", input, "--output-format", "yaml");
+    }
+
+    /// <inheritdoc/>
+    public Task<DSCProcessResult> TestResourceAsync(string resource, string input)
+    {
+        _logger.LogInformation($"Testing state for DSC resource: {resource}");
+        return ExecuteAsync("resource", "test", "--resource", resource, "--input", input, "--output-format", "yaml");
     }
 
     /// <summary>


### PR DESCRIPTION
…dationViewModel to utilize them

## 📖 Description

This PR updates the DSC operation outputs in `ValidationViewMOdel`. Its to display the complete resource state information to match the structure `dsc.exe` returnes. Also reconstructured `get` and `test` around this. 

I made this choice, as I expect users to see the same detailed output in WinGet Studio as when they do with `dsc resource <operation>`. I investigated if the COM API could use it, but the handler filters this data down to only the basic properties when creating the WinRT COM objects.

## 🔗 References and Related Issues

## 🔍 How to Test

## ✅ Checklist
- [x] Closes #151 and #150.
- [ ] Tests added/passed
- [ ] Documentation updated
