### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdownLint.yaml
+++ b/.github/workflows/markdownLint.yaml
@@ -1,4 +1,6 @@
 name: Markdown Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/winget-studio/security/code-scanning/1](https://github.com/microsoft/winget-studio/security/code-scanning/1)

To fix this problem, we should add a `permissions` block to reduce the workflow's GITHUB_TOKEN access to the minimal set required—in this case, read-access to repository contents. The block should be placed either at the root of the workflow file (so it applies to all jobs), or specifically under the `jobs.lint` job (but the root is preferred for clarity and coverage). In this workflow, putting it just below the `name` field at the top, before `on:`, is the established convention. Adding `permissions: contents: read` will ensure that the workflow adheres to the principle of least privilege, mitigating security risks from unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
