### PR TITLE
Only run MarkdownLint when changing markdown files

### DIFF
--- a/.github/workflows/markdownLint.yaml
+++ b/.github/workflows/markdownLint.yaml
@@ -9,11 +9,15 @@ on:
       - '!main'
     tags-ignore:
       - '**'
+    paths:
+      - "**/*.md"
   pull_request_target:
     branches:
       - '**'
     tags-ignore:
       - '**'
+    paths:
+      - "**/*.md"
     types:
       - 'opened'
       - 'reopened'


### PR DESCRIPTION
## 📖 Description
Adds the `paths` to the trigger for the workflow so that it doesn't run unless a markdown file is changed

## 🔗 References and Related Issues

## 🔍 How to Test

## ✅ Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
