### PR TITLE
Use different checkout based on event trigger

### DIFF
--- a/.github/workflows/markdownLint.yaml
+++ b/.github/workflows/markdownLint.yaml
@@ -28,13 +28,25 @@ jobs:
     name: Check Markdown linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout (pull_request_target -> head repo)
+      if: github.event_name == 'pull_request_target'
+      uses: actions/checkout@v4
+      with:
+        # When running under pull_request_target, checkout the head repo/sha
+        # so the runner can find the exact commit (handles forked PRs).
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Checkout (default)
+      if: github.event_name != 'pull_request_target'
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: tj-actions/changed-files@v45
+    - uses: tj-actions/changed-files@v47.0.0
       id: changed-files
       with:
-        files: '**/*.md'
+        files: |
+          **/*.md
     - uses: DavidAnson/markdownlint-cli2-action@v17
       if: steps.changed-files.outputs.any_changed == 'true'
       with:


### PR DESCRIPTION
## 📖 Description
Based on the error messages in the actions log for Markdown Lint, if the pull request is from a forked repository, the checkout needs to happen from the forked repository. Since this is now a public repo all of the forks should also be public, allowing the checkout to work properly . . . if the correct repository is specified in the checkout action.

This PR updates the workflow so that if the trigger comes from a pull request, it will check out the repository of the pull request at the head of that pull request. If the trigger is not from a pull request, it will check out the current repository since the action is running on a branch that is being pushed to and there is no need to check out from a different repository for comparing against the previous commit on that same branch.

## 🔗 References and Related Issues

## 🔍 How to Test

## ✅ Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated

cc @Gijsreyn 