### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish-winget:
     name: Submit to WinGet repository
+    permissions:
+      contents: read
+      pull-requests: write
 
     # winget-create is only supported on Windows
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/winget-studio/security/code-scanning/2](https://github.com/microsoft/winget-studio/security/code-scanning/2)

To fix this issue, add a `permissions` block to the job or the root of the workflow YAML file. For this case, since the flagged error is within the `publish-winget` job, the best fix is to set a minimal permissions block inside that job. This block should give `contents: read` (required to read repo contents) and only grant `pull-requests: write` if the workflow might submit PRs using wingetcreate. Place it as the first key under the job (before `runs-on` is standard). No functional changes elsewhere are needed; just add this YAML section. Specifically, add:

```yaml
permissions:
  contents: read
  pull-requests: write
```

as lines immediately below line 9 in `.github/workflows/winget.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
