### PR TITLE
Add DAG visualization

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -25,6 +25,9 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
     <!-- WinGet -->
     <PackageVersion Include="Microsoft.WindowsPackageManager.Configuration.OutOfProc" Version="1.12.350" />
+    <!-- Graph layout -->
+    <PackageVersion Include="AutomaticGraphLayout" Version="1.1.12" />
+    <PackageVersion Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
     <!-- WinUI and related -->
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.6.1" />

--- a/src/WinGetStudio.Tests.MSTest/DagLayoutServiceTests.cs
+++ b/src/WinGetStudio.Tests.MSTest/DagLayoutServiceTests.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using WinGetStudio.Models.Graph;
+using WinGetStudio.ViewModels;
+
+namespace WinGetStudio.Tests.MSTest;
+
+[TestClass]
+public class DagLayoutServiceTests
+{
+    private static UnitViewModel CreateUnit(string id, string? title = null, List<UnitViewModel>? dependencies = null)
+    {
+        var unit = new UnitViewModel(null!, null!, null!, null!)
+        {
+            Id = id,
+            Title = title ?? id,
+            Dependencies = dependencies ?? [],
+        };
+        return unit;
+    }
+
+    [TestMethod]
+    public void ComputeLayout_EmptyList_ReturnsEmptyResult()
+    {
+        var result = DagLayoutService.ComputeLayout([]);
+
+        Assert.AreEqual(0, result.Nodes.Count);
+        Assert.AreEqual(0, result.Edges.Count);
+        Assert.AreEqual(0, result.TotalWidth);
+        Assert.AreEqual(0, result.TotalHeight);
+    }
+
+    [TestMethod]
+    public void ComputeLayout_NullList_ReturnsEmptyResult()
+    {
+        var result = DagLayoutService.ComputeLayout(null!);
+
+        Assert.AreEqual(0, result.Nodes.Count);
+        Assert.AreEqual(0, result.Edges.Count);
+    }
+
+    [TestMethod]
+    public void ComputeLayout_SingleNode_ReturnsOneNodeNoEdges()
+    {
+        var unit = CreateUnit("A");
+        var result = DagLayoutService.ComputeLayout([unit]);
+
+        Assert.AreEqual(1, result.Nodes.Count);
+        Assert.AreEqual(0, result.Edges.Count);
+        Assert.AreEqual("A", result.Nodes[0].Id);
+        Assert.AreEqual("A", result.Nodes[0].Label);
+        Assert.IsTrue(result.Nodes[0].Width > 0);
+        Assert.IsTrue(result.Nodes[0].Height > 0);
+    }
+
+    [TestMethod]
+    public void ComputeLayout_LinearChain_CreatesCorrectEdges()
+    {
+        var unitA = CreateUnit("A");
+        var unitB = CreateUnit("B", dependencies: [unitA]);
+        var unitC = CreateUnit("C", dependencies: [unitB]);
+
+        var result = DagLayoutService.ComputeLayout([unitA, unitB, unitC]);
+
+        Assert.AreEqual(3, result.Nodes.Count);
+        Assert.AreEqual(2, result.Edges.Count);
+
+        // Verify edge directions: A→B and B→C (order of operations).
+        var edgeAB = result.Edges.FirstOrDefault(e => e.Source.Id == "A" && e.Target.Id == "B");
+        var edgeBC = result.Edges.FirstOrDefault(e => e.Source.Id == "B" && e.Target.Id == "C");
+        Assert.IsNotNull(edgeAB, "Expected edge from A to B");
+        Assert.IsNotNull(edgeBC, "Expected edge from B to C");
+    }
+
+    [TestMethod]
+    public void ComputeLayout_DiamondPattern_CreatesFourEdges()
+    {
+        //   A
+        //  / \
+        // B   C
+        //  \ /
+        //   D
+        var unitA = CreateUnit("A");
+        var unitB = CreateUnit("B", dependencies: [unitA]);
+        var unitC = CreateUnit("C", dependencies: [unitA]);
+        var unitD = CreateUnit("D", dependencies: [unitB, unitC]);
+
+        var result = DagLayoutService.ComputeLayout([unitA, unitB, unitC, unitD]);
+
+        Assert.AreEqual(4, result.Nodes.Count);
+        Assert.AreEqual(4, result.Edges.Count);
+    }
+
+    [TestMethod]
+    public void ComputeLayout_AllNodesGetPositiveCoordinates()
+    {
+        var unitA = CreateUnit("A");
+        var unitB = CreateUnit("B", dependencies: [unitA]);
+        var unitC = CreateUnit("C", dependencies: [unitA]);
+
+        var result = DagLayoutService.ComputeLayout([unitA, unitB, unitC]);
+
+        foreach (var node in result.Nodes)
+        {
+            Assert.IsTrue(node.X >= 0, $"Node {node.Id} has negative X: {node.X}");
+            Assert.IsTrue(node.Y >= 0, $"Node {node.Id} has negative Y: {node.Y}");
+        }
+    }
+
+    [TestMethod]
+    public void ComputeLayout_EdgesHavePathData()
+    {
+        var unitA = CreateUnit("A");
+        var unitB = CreateUnit("B", dependencies: [unitA]);
+
+        var result = DagLayoutService.ComputeLayout([unitA, unitB]);
+
+        Assert.AreEqual(1, result.Edges.Count);
+        Assert.IsFalse(string.IsNullOrEmpty(result.Edges[0].PathData), "Edge should have path data");
+    }
+
+    [TestMethod]
+    public void ComputeLayout_TotalDimensions_ArePositive()
+    {
+        var unitA = CreateUnit("A");
+        var unitB = CreateUnit("B", dependencies: [unitA]);
+
+        var result = DagLayoutService.ComputeLayout([unitA, unitB]);
+
+        Assert.IsTrue(result.TotalWidth > 0, "Total width should be positive");
+        Assert.IsTrue(result.TotalHeight > 0, "Total height should be positive");
+    }
+
+    [TestMethod]
+    public void ComputeLayout_IndependentNodes_AllGetPositions()
+    {
+        var unitA = CreateUnit("A");
+        var unitB = CreateUnit("B");
+        var unitC = CreateUnit("C");
+
+        var result = DagLayoutService.ComputeLayout([unitA, unitB, unitC]);
+
+        Assert.AreEqual(3, result.Nodes.Count);
+        Assert.AreEqual(0, result.Edges.Count);
+
+        // All nodes should have unique positions.
+        var positions = result.Nodes.Select(n => (n.X, n.Y)).ToHashSet();
+        Assert.AreEqual(3, positions.Count, "All nodes should have unique positions");
+    }
+
+    [TestMethod]
+    public void ComputeLayout_PreservesUnitViewModelReference()
+    {
+        var unitA = CreateUnit("A", "Resource A");
+
+        var result = DagLayoutService.ComputeLayout([unitA]);
+
+        Assert.AreSame(unitA, result.Nodes[0].Unit);
+        Assert.AreEqual("Resource A", result.Nodes[0].Label);
+    }
+
+    [TestMethod]
+    public void ComputeLayout_WideFanOut_CreatesCorrectEdges()
+    {
+        var root = CreateUnit("root");
+        var children = Enumerable.Range(1, 5)
+            .Select(i => CreateUnit($"child{i}", dependencies: [root]))
+            .ToList();
+
+        var allUnits = new List<UnitViewModel> { root };
+        allUnits.AddRange(children);
+
+        var result = DagLayoutService.ComputeLayout(allUnits);
+
+        Assert.AreEqual(6, result.Nodes.Count);
+        Assert.AreEqual(5, result.Edges.Count);
+    }
+}

--- a/src/WinGetStudio/App.xaml.cs
+++ b/src/WinGetStudio/App.xaml.cs
@@ -118,6 +118,8 @@ public partial class App : Application
                 services.AddTransient<PreviewFileViewModel>();
                 services.AddTransient<ApplyFilePage>();
                 services.AddTransient<ApplyFileViewModel>();
+                services.AddTransient<DagPage>();
+                services.AddTransient<DagViewModel>();
                 services.AddTransient<NotificationPaneViewModel>();
                 services.AddTransient<LoadingProgressBarViewModel>();
                 services.AddTransient<ResourceAutoSuggestBoxViewModel>();

--- a/src/WinGetStudio/Models/Graph/DagEdge.cs
+++ b/src/WinGetStudio/Models/Graph/DagEdge.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace WinGetStudio.Models.Graph;
+
+/// <summary>
+/// Represents a directed edge in the DAG visualization.
+/// The edge goes from the dependency node (Source) to the dependent node (Target),
+/// indicating order of operations: Source must complete before Target.
+/// </summary>
+public partial class DagEdge : ObservableObject
+{
+    public DagEdge(DagNode source, DagNode target)
+    {
+        Source = source;
+        Target = target;
+    }
+
+    /// <summary>
+    /// Gets the source node (the dependency — runs first).
+    /// </summary>
+    public DagNode Source { get; }
+
+    /// <summary>
+    /// Gets the target node (the dependent — runs after source).
+    /// </summary>
+    public DagNode Target { get; }
+
+    /// <summary>
+    /// Gets or sets the SVG-style path data string for rendering the edge.
+    /// </summary>
+    [ObservableProperty]
+    public partial string PathData { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the arrowhead path data string.
+    /// </summary>
+    [ObservableProperty]
+    public partial string ArrowHeadData { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether this edge is highlighted.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsHighlighted { get; set; }
+}

--- a/src/WinGetStudio/Models/Graph/DagLayoutService.cs
+++ b/src/WinGetStudio/Models/Graph/DagLayoutService.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using Microsoft.Msagl.Core.Geometry;
+using Microsoft.Msagl.Core.Geometry.Curves;
+using Microsoft.Msagl.Core.Layout;
+using Microsoft.Msagl.Core.Routing;
+using Microsoft.Msagl.Layout.Layered;
+using WinGetStudio.ViewModels;
+
+namespace WinGetStudio.Models.Graph;
+
+/// <summary>
+/// Translates UnitViewModels into a positioned DAG layout using MSAGL's Sugiyama algorithm.
+/// </summary>
+public static class DagLayoutService
+{
+    private const double DefaultNodeWidth = 200;
+    private const double DefaultNodeHeight = 60;
+    private const double ArrowHeadSize = 8;
+
+    /// <summary>
+    /// Computes the DAG layout for the given set of units and their dependencies.
+    /// </summary>
+    /// <param name="units">The configuration units to lay out.</param>
+    /// <returns>The computed nodes and edges with positions.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a cycle is detected.</exception>
+    public static DagLayoutResult ComputeLayout(IReadOnlyList<UnitViewModel> units)
+    {
+        if (units == null || units.Count == 0)
+        {
+            return new DagLayoutResult([], []);
+        }
+
+        var graph = new GeometryGraph();
+        var nodeMap = new Dictionary<string, (Microsoft.Msagl.Core.Layout.Node MsaglNode, DagNode DagNode)>();
+
+        // Create MSAGL nodes for each unit.
+        foreach (var unit in units)
+        {
+            var id = unit.IdOrDefault;
+            var label = unit.Title ?? id;
+
+            var dagNode = new DagNode(unit, id) { Label = label };
+            var msaglNode = new Microsoft.Msagl.Core.Layout.Node(
+                CurveFactory.CreateRectangle(DefaultNodeWidth, DefaultNodeHeight, new Point(0, 0)),
+                id);
+
+            graph.Nodes.Add(msaglNode);
+            nodeMap[id] = (msaglNode, dagNode);
+        }
+
+        // Create edges for dependencies.
+        // Edge direction: dependency → dependent (arrow shows order of operations).
+        var edgePairs = new List<(Microsoft.Msagl.Core.Layout.Edge MsaglEdge, DagEdge DagEdge)>();
+        foreach (var unit in units)
+        {
+            if (unit.Dependencies == null)
+            {
+                continue;
+            }
+
+            var dependentId = unit.IdOrDefault;
+            foreach (var dep in unit.Dependencies)
+            {
+                var dependencyId = dep.IdOrDefault;
+                if (nodeMap.TryGetValue(dependencyId, out var dependency) && nodeMap.TryGetValue(dependentId, out var dependent))
+                {
+                    var msaglEdge = new Microsoft.Msagl.Core.Layout.Edge(dependency.MsaglNode, dependent.MsaglNode)
+                    {
+                        EdgeGeometry = new EdgeGeometry { TargetArrowhead = new Arrowhead() },
+                    };
+                    graph.Edges.Add(msaglEdge);
+
+                    var dagEdge = new DagEdge(dependency.DagNode, dependent.DagNode);
+                    edgePairs.Add((msaglEdge, dagEdge));
+                }
+            }
+        }
+
+        // Run MSAGL Sugiyama layout.
+        var settings = new SugiyamaLayoutSettings
+        {
+            EdgeRoutingSettings = { EdgeRoutingMode = EdgeRoutingMode.Spline },
+        };
+
+        var layout = new LayeredLayout(graph, settings);
+        layout.Run();
+
+        // Read back positions from MSAGL and normalize so the top-left is near (0,0).
+        // MSAGL uses Y-up coordinates; WinUI Canvas uses Y-down, so we flip the Y axis.
+        var minX = graph.Nodes.Min(n => n.BoundingBox.Left);
+        var maxY = graph.Nodes.Max(n => n.BoundingBox.Top);
+        var padding = 40.0;
+
+        var dagNodes = new List<DagNode>();
+        foreach (var entry in nodeMap.Values)
+        {
+            var msaglNode = entry.MsaglNode;
+            var dagNode = entry.DagNode;
+
+            dagNode.X = msaglNode.BoundingBox.Left - minX + padding;
+            dagNode.Y = maxY - msaglNode.BoundingBox.Top + padding;
+            dagNode.Width = msaglNode.BoundingBox.Width;
+            dagNode.Height = msaglNode.BoundingBox.Height;
+
+            dagNodes.Add(dagNode);
+        }
+
+        // Build edge path data from MSAGL spline geometry.
+        var dagEdges = new List<DagEdge>();
+        foreach (var (msaglEdge, dagEdge) in edgePairs)
+        {
+            dagEdge.PathData = BuildEdgePathData(msaglEdge, minX, maxY, padding);
+            dagEdge.ArrowHeadData = BuildArrowHeadData(msaglEdge, minX, maxY, padding);
+            dagEdges.Add(dagEdge);
+        }
+
+        return new DagLayoutResult(dagNodes, dagEdges);
+    }
+
+    /// <summary>
+    /// Converts an MSAGL edge curve into a XAML path data string.
+    /// </summary>
+    private static string BuildEdgePathData(Microsoft.Msagl.Core.Layout.Edge edge, double minX, double maxY, double padding)
+    {
+        var curve = edge.Curve;
+        if (curve == null)
+        {
+            return string.Empty;
+        }
+
+        return curve switch
+        {
+            Curve compositeCurve => BuildCompositeCurvePathData(compositeCurve, minX, maxY, padding),
+            LineSegment line => BuildLinePathData(line, minX, maxY, padding),
+            CubicBezierSegment bezier => BuildBezierPathData(bezier, minX, maxY, padding),
+            _ => string.Empty,
+        };
+    }
+
+    /// <summary>
+    /// Converts a composite MSAGL curve (multiple segments) into a XAML path data string.
+    /// </summary>
+    private static string BuildCompositeCurvePathData(Curve curve, double minX, double maxY, double padding)
+    {
+        var segments = curve.Segments.ToList();
+        if (segments.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var path = new System.Text.StringBuilder();
+        var first = segments[0];
+        var startPoint = TranslatePoint(first.Start, minX, maxY, padding);
+        path.Append(CultureInfo.InvariantCulture, $"M {startPoint.X:F1} {startPoint.Y:F1}");
+
+        foreach (var segment in segments)
+        {
+            if (segment is CubicBezierSegment bezier)
+            {
+                var b1 = TranslatePoint(bezier.B(1), minX, maxY, padding);
+                var b2 = TranslatePoint(bezier.B(2), minX, maxY, padding);
+                var b3 = TranslatePoint(bezier.B(3), minX, maxY, padding);
+                path.Append(CultureInfo.InvariantCulture, $" C {b1.X:F1} {b1.Y:F1} {b2.X:F1} {b2.Y:F1} {b3.X:F1} {b3.Y:F1}");
+            }
+            else if (segment is LineSegment line)
+            {
+                var end = TranslatePoint(line.End, minX, maxY, padding);
+                path.Append(CultureInfo.InvariantCulture, $" L {end.X:F1} {end.Y:F1}");
+            }
+        }
+
+        return path.ToString();
+    }
+
+    /// <summary>
+    /// Converts an MSAGL line segment into a XAML path data string.
+    /// </summary>
+    private static string BuildLinePathData(LineSegment line, double minX, double maxY, double padding)
+    {
+        var start = TranslatePoint(line.Start, minX, maxY, padding);
+        var end = TranslatePoint(line.End, minX, maxY, padding);
+        return string.Create(CultureInfo.InvariantCulture, $"M {start.X:F1} {start.Y:F1} L {end.X:F1} {end.Y:F1}");
+    }
+
+    /// <summary>
+    /// Converts an MSAGL cubic Bézier segment into a XAML path data string.
+    /// </summary>
+    private static string BuildBezierPathData(CubicBezierSegment bezier, double minX, double maxY, double padding)
+    {
+        var b0 = TranslatePoint(bezier.B(0), minX, maxY, padding);
+        var b1 = TranslatePoint(bezier.B(1), minX, maxY, padding);
+        var b2 = TranslatePoint(bezier.B(2), minX, maxY, padding);
+        var b3 = TranslatePoint(bezier.B(3), minX, maxY, padding);
+        return string.Create(CultureInfo.InvariantCulture, $"M {b0.X:F1} {b0.Y:F1} C {b1.X:F1} {b1.Y:F1} {b2.X:F1} {b2.Y:F1} {b3.X:F1} {b3.Y:F1}");
+    }
+
+    /// <summary>
+    /// Builds a triangular arrowhead path data string at the target end of an edge.
+    /// </summary>
+    private static string BuildArrowHeadData(Microsoft.Msagl.Core.Layout.Edge edge, double minX, double maxY, double padding)
+    {
+        var arrowhead = edge.EdgeGeometry?.TargetArrowhead;
+        if (arrowhead == null)
+        {
+            return string.Empty;
+        }
+
+        var tip = TranslatePoint(arrowhead.TipPosition, minX, maxY, padding);
+
+        // Compute arrowhead direction from the edge curve's end tangent.
+        var curve = edge.Curve;
+        if (curve == null)
+        {
+            return string.Empty;
+        }
+
+        var msaglDirection = (curve.End - curve[curve.ParEnd - 0.01]).Normalize();
+
+        // Flip Y to match the canvas coordinate system (Y-down).
+        var direction = new Point(msaglDirection.X, -msaglDirection.Y);
+        var perpendicular = new Point(-direction.Y, direction.X);
+
+        var left = new Point(
+            tip.X - (direction.X * ArrowHeadSize) + (perpendicular.X * ArrowHeadSize / 2),
+            tip.Y - (direction.Y * ArrowHeadSize) + (perpendicular.Y * ArrowHeadSize / 2));
+        var right = new Point(
+            tip.X - (direction.X * ArrowHeadSize) - (perpendicular.X * ArrowHeadSize / 2),
+            tip.Y - (direction.Y * ArrowHeadSize) - (perpendicular.Y * ArrowHeadSize / 2));
+
+        return string.Create(CultureInfo.InvariantCulture, $"M {tip.X:F1} {tip.Y:F1} L {left.X:F1} {left.Y:F1} L {right.X:F1} {right.Y:F1} Z");
+    }
+
+    /// <summary>
+    /// Translates an MSAGL point to canvas coordinates by applying the normalization offset,
+    /// Y-axis flip (MSAGL Y-up to WinUI Y-down), and padding.
+    /// </summary>
+    private static Point TranslatePoint(Point point, double minX, double maxY, double padding)
+    {
+        return new Point(point.X - minX + padding, maxY - point.Y + padding);
+    }
+}
+
+/// <summary>
+/// Contains the result of a DAG layout computation.
+/// </summary>
+public sealed class DagLayoutResult
+{
+    public DagLayoutResult(IReadOnlyList<DagNode> nodes, IReadOnlyList<DagEdge> edges)
+    {
+        Nodes = nodes;
+        Edges = edges;
+    }
+
+    public IReadOnlyList<DagNode> Nodes { get; }
+
+    public IReadOnlyList<DagEdge> Edges { get; }
+
+    /// <summary>
+    /// Gets the total width needed for the canvas.
+    /// </summary>
+    public double TotalWidth => Nodes.Count > 0 ? Nodes.Max(n => n.X + n.Width) + 40 : 0;
+
+    /// <summary>
+    /// Gets the total height needed for the canvas.
+    /// </summary>
+    public double TotalHeight => Nodes.Count > 0 ? Nodes.Max(n => n.Y + n.Height) + 40 : 0;
+}

--- a/src/WinGetStudio/Models/Graph/DagNode.cs
+++ b/src/WinGetStudio/Models/Graph/DagNode.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using WinGetStudio.ViewModels;
+
+namespace WinGetStudio.Models.Graph;
+
+/// <summary>
+/// Represents a node in the DAG visualization, positioned by the layout engine.
+/// </summary>
+public partial class DagNode : ObservableObject
+{
+    public DagNode(UnitViewModel unit, string id)
+    {
+        Unit = unit;
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the unique identifier for this node (matches the unit's IdOrDefault).
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the source UnitViewModel this node represents.
+    /// </summary>
+    public UnitViewModel Unit { get; }
+
+    /// <summary>
+    /// Gets or sets the display label (resource type / name).
+    /// </summary>
+    [ObservableProperty]
+    public partial string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the X coordinate computed by the layout engine.
+    /// </summary>
+    [ObservableProperty]
+    public partial double X { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Y coordinate computed by the layout engine.
+    /// </summary>
+    [ObservableProperty]
+    public partial double Y { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of this node.
+    /// </summary>
+    [ObservableProperty]
+    public partial double Width { get; set; } = 200;
+
+    /// <summary>
+    /// Gets or sets the height of this node.
+    /// </summary>
+    [ObservableProperty]
+    public partial double Height { get; set; } = 60;
+
+    /// <summary>
+    /// Gets or sets whether this node is currently selected.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsSelected { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this node is highlighted (as a dependency of the selected node).
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsHighlighted { get; set; }
+}

--- a/src/WinGetStudio/Services/Navigation/ConfigurationPageService.cs
+++ b/src/WinGetStudio/Services/Navigation/ConfigurationPageService.cs
@@ -13,5 +13,6 @@ internal sealed class ConfigurationPageService : PageService, IConfigurationPage
     {
         Configure<PreviewFileViewModel, PreviewFilePage>();
         Configure<ApplyFileViewModel, ApplyFilePage>();
+        Configure<DagViewModel, DagPage>();
     }
 }

--- a/src/WinGetStudio/Strings/en-us/Resources.resw
+++ b/src/WinGetStudio/Strings/en-us/Resources.resw
@@ -563,6 +563,21 @@
   <data name="PreviewPage_SaveAs.Label" xml:space="preserve">
     <value>Save As</value>
   </data>
+  <data name="PreviewPage_VisualizeDependencies.Label" xml:space="preserve">
+    <value>Visualize</value>
+  </data>
+  <data name="DagPage_Back.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="DagPage_Title.Text" xml:space="preserve">
+    <value>Dependency Graph</value>
+  </data>
+  <data name="DagPage_LayoutError.Title" xml:space="preserve">
+    <value>Layout Error</value>
+  </data>
+  <data name="DagPage_EmptyState.Text" xml:space="preserve">
+    <value>No configuration units to visualize</value>
+  </data>
   <data name="PreviewPage_FilePicker_ConfigurationFiles" xml:space="preserve">
     <value>Configuration files</value>
   </data>

--- a/src/WinGetStudio/ViewModels/ConfigurationFlow/DagViewModel.cs
+++ b/src/WinGetStudio/ViewModels/ConfigurationFlow/DagViewModel.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using WinGetStudio.Contracts.Services;
+using WinGetStudio.Models.Graph;
+using WinGetStudio.ViewModels;
+
+namespace WinGetStudio.ViewModels.ConfigurationFlow;
+
+/// <summary>
+/// ViewModel for the DAG dependency graph visualization page.
+/// Builds a visual graph from the active configuration set's units and their dependencies.
+/// </summary>
+public partial class DagViewModel : ObservableRecipient
+{
+    private readonly ILogger<DagViewModel> _logger;
+    private readonly IConfigurationManager _manager;
+    private readonly IConfigurationFrameNavigationService _navigationService;
+
+    [ObservableProperty]
+    public partial ObservableCollection<DagNode> Nodes { get; set; } = [];
+
+    [ObservableProperty]
+    public partial ObservableCollection<DagEdge> Edges { get; set; } = [];
+
+    [ObservableProperty]
+    public partial double CanvasWidth { get; set; }
+
+    [ObservableProperty]
+    public partial double CanvasHeight { get; set; }
+
+    [ObservableProperty]
+    public partial bool HasCycleError { get; set; }
+
+    [ObservableProperty]
+    public partial string? ErrorMessage { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsEmpty { get; set; }
+
+    public DagViewModel(
+        ILogger<DagViewModel> logger,
+        IConfigurationManager manager,
+        IConfigurationFrameNavigationService navigationService)
+    {
+        _logger = logger;
+        _manager = manager;
+        _navigationService = navigationService;
+    }
+
+    [RelayCommand]
+    private void OnLoaded()
+    {
+        BuildGraph();
+    }
+
+    [RelayCommand]
+    private void OnBack()
+    {
+        _navigationService.NavigateToDefaultPage();
+    }
+
+    /// <summary>
+    /// Toggles the selected state of a node and highlights its direct dependencies and dependents.
+    /// </summary>
+    /// <param name="selectedNode">The node that was tapped.</param>
+    public void OnNodeSelected(DagNode selectedNode)
+    {
+        foreach (var node in Nodes)
+        {
+            node.IsSelected = node == selectedNode && !node.IsSelected;
+            node.IsHighlighted = false;
+        }
+
+        foreach (var edge in Edges)
+        {
+            edge.IsHighlighted = false;
+        }
+
+        if (selectedNode.IsSelected)
+        {
+            // Highlight direct dependencies and dependents.
+            foreach (var edge in Edges)
+            {
+                if (edge.Source == selectedNode || edge.Target == selectedNode)
+                {
+                    edge.IsHighlighted = true;
+                    var otherNode = edge.Source == selectedNode ? edge.Target : edge.Source;
+                    otherNode.IsHighlighted = true;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the DAG graph from the active configuration set's units and dependencies.
+    /// Populates the Nodes and Edges collections with positioned elements.
+    /// </summary>
+    private void BuildGraph()
+    {
+        _logger.LogInformation("Building DAG visualization");
+        Nodes.Clear();
+        Edges.Clear();
+        HasCycleError = false;
+        ErrorMessage = null;
+
+        var activePreviewSet = _manager.ActiveSetPreviewState.ActivePreviewSet;
+        var configSet = activePreviewSet?.ConfigurationSet;
+
+        if (configSet == null || configSet.Units.Count == 0)
+        {
+            IsEmpty = true;
+            _logger.LogInformation("No configuration units to visualize");
+            return;
+        }
+
+        IsEmpty = false;
+
+        try
+        {
+            var result = DagLayoutService.ComputeLayout(configSet.Units.ToList());
+
+            foreach (var node in result.Nodes)
+            {
+                Nodes.Add(node);
+            }
+
+            foreach (var edge in result.Edges)
+            {
+                Edges.Add(edge);
+            }
+
+            CanvasWidth = result.TotalWidth;
+            CanvasHeight = result.TotalHeight;
+
+            _logger.LogInformation("DAG visualization built with {NodeCount} nodes and {EdgeCount} edges", Nodes.Count, Edges.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to compute DAG layout");
+            HasCycleError = true;
+            ErrorMessage = ex.Message;
+        }
+    }
+}

--- a/src/WinGetStudio/ViewModels/ConfigurationFlow/PreviewFileViewModel.cs
+++ b/src/WinGetStudio/ViewModels/ConfigurationFlow/PreviewFileViewModel.cs
@@ -12,16 +12,18 @@ public partial class PreviewFileViewModel : ObservableRecipient
 {
     private readonly IConfigurationManager _manager;
     private readonly PreviewSetViewModelFactory _setFactory;
+    private readonly IConfigurationFrameNavigationService _navigationService;
 
     public IReadOnlyList<UnitSecurityContext> SecurityContexts => UnitSecurityContext.All;
 
     [ObservableProperty]
     public partial PreviewSetViewModel? PreviewSet { get; set; }
 
-    public PreviewFileViewModel(IConfigurationManager manager, PreviewSetViewModelFactory setFactory)
+    public PreviewFileViewModel(IConfigurationManager manager, PreviewSetViewModelFactory setFactory, IConfigurationFrameNavigationService navigationService)
     {
         _manager = manager;
         _setFactory = setFactory;
+        _navigationService = navigationService;
     }
 
     [RelayCommand]
@@ -42,5 +44,15 @@ public partial class PreviewFileViewModel : ObservableRecipient
     private void OnUnloaded()
     {
         _manager.ActiveSetPreviewState.CaptureState(this);
+    }
+
+    /// <summary>
+    /// Saves the current preview state and navigates to the DAG visualization page.
+    /// </summary>
+    [RelayCommand]
+    private void NavigateToDag()
+    {
+        _manager.ActiveSetPreviewState.CaptureState(this);
+        _navigationService.NavigateTo<DagViewModel>();
     }
 }

--- a/src/WinGetStudio/Views/ConfigurationFlow/DagNodeControl.xaml
+++ b/src/WinGetStudio/Views/ConfigurationFlow/DagNodeControl.xaml
@@ -1,0 +1,57 @@
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- Licensed under the MIT License. -->
+<UserControl
+    x:Class="WinGetStudio.Views.ConfigurationFlow.DagNodeControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:graph="using:WinGetStudio.Models.Graph"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <converters:StringVisibilityConverter x:Key="StringToVisibilityConverter" />
+    </UserControl.Resources>
+
+    <Border x:Name="NodeBorder"
+            Width="{x:Bind Node.Width, Mode=OneWay}"
+            Height="{x:Bind Node.Height, Mode=OneWay}"
+            CornerRadius="8"
+            Padding="12,8"
+            BorderThickness="2"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            PointerEntered="OnPointerEntered"
+            PointerExited="OnPointerExited"
+            Tapped="OnNodeTapped">
+        <ToolTipService.ToolTip>
+            <StackPanel Spacing="4" MaxWidth="300">
+                <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="{x:Bind Node.Label, Mode=OneWay}" TextWrapping="Wrap" />
+                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="{x:Bind Node.Id, Mode=OneWay}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="{x:Bind Node.Unit.Description, Mode=OneWay}" TextWrapping="Wrap"
+                           Visibility="{x:Bind Node.Unit.Description, Mode=OneWay, Converter={StaticResource StringToVisibilityConverter}}" />
+            </StackPanel>
+        </ToolTipService.ToolTip>
+
+        <Grid ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <FontIcon Glyph="&#xE835;" FontSize="16" VerticalAlignment="Center"
+                      Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                <TextBlock Text="{x:Bind Node.Label, Mode=OneWay}"
+                           Style="{ThemeResource BodyStrongTextBlockStyle}"
+                           TextTrimming="CharacterEllipsis"
+                           MaxLines="1" />
+                <TextBlock Text="{x:Bind Node.Id, Mode=OneWay}"
+                           Style="{ThemeResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           TextTrimming="CharacterEllipsis"
+                           MaxLines="1" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/WinGetStudio/Views/ConfigurationFlow/DagNodeControl.xaml.cs
+++ b/src/WinGetStudio/Views/ConfigurationFlow/DagNodeControl.xaml.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using WinGetStudio.Models.Graph;
+
+namespace WinGetStudio.Views.ConfigurationFlow;
+
+/// <summary>
+/// A control that renders a single node in the DAG visualization.
+/// Displays the resource type icon, label, and ID with interactive selection and hover states.
+/// </summary>
+public sealed partial class DagNodeControl : UserControl
+{
+    private static readonly SolidColorBrush SelectedBorderBrush = new(Microsoft.UI.Colors.CornflowerBlue);
+    private static readonly SolidColorBrush HighlightedBorderBrush = new(Microsoft.UI.Colors.Orange);
+
+    public DagNode Node
+    {
+        get => (DagNode)GetValue(NodeProperty);
+        set => SetValue(NodeProperty, value);
+    }
+
+    public static readonly DependencyProperty NodeProperty =
+        DependencyProperty.Register(nameof(Node), typeof(DagNode), typeof(DagNodeControl), new PropertyMetadata(null, OnNodeChanged));
+
+    public event EventHandler<DagNode>? NodeTapped;
+
+    public DagNodeControl()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnNodeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is DagNodeControl control)
+        {
+            if (e.OldValue is DagNode oldNode)
+            {
+                oldNode.PropertyChanged -= control.OnNodePropertyChanged;
+            }
+
+            if (e.NewValue is DagNode newNode)
+            {
+                newNode.PropertyChanged += control.OnNodePropertyChanged;
+                control.UpdateVisualState();
+            }
+        }
+    }
+
+    private void OnNodePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(DagNode.IsSelected) or nameof(DagNode.IsHighlighted))
+        {
+            DispatcherQueue.TryEnqueue(UpdateVisualState);
+        }
+    }
+
+    /// <summary>
+    /// Updates the border brush and thickness based on the node's selected/highlighted state.
+    /// </summary>
+    private void UpdateVisualState()
+    {
+        if (Node == null)
+        {
+            return;
+        }
+
+        if (Node.IsSelected)
+        {
+            NodeBorder.BorderBrush = SelectedBorderBrush;
+            NodeBorder.BorderThickness = new Thickness(3);
+        }
+        else if (Node.IsHighlighted)
+        {
+            NodeBorder.BorderBrush = HighlightedBorderBrush;
+            NodeBorder.BorderThickness = new Thickness(2.5);
+        }
+        else
+        {
+            NodeBorder.BorderBrush = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"];
+            NodeBorder.BorderThickness = new Thickness(2);
+        }
+    }
+
+    private void OnPointerEntered(object sender, PointerRoutedEventArgs e)
+    {
+        if (!Node?.IsSelected ?? false)
+        {
+            NodeBorder.Background = (Brush)Application.Current.Resources["CardBackgroundFillColorSecondaryBrush"];
+        }
+    }
+
+    private void OnPointerExited(object sender, PointerRoutedEventArgs e)
+    {
+        NodeBorder.Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"];
+    }
+
+    private void OnNodeTapped(object sender, TappedRoutedEventArgs e)
+    {
+        if (Node != null)
+        {
+            NodeTapped?.Invoke(this, Node);
+        }
+    }
+}

--- a/src/WinGetStudio/Views/ConfigurationFlow/DagPage.xaml
+++ b/src/WinGetStudio/Views/ConfigurationFlow/DagPage.xaml
@@ -1,0 +1,77 @@
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- Licensed under the MIT License. -->
+<Page
+    x:Class="WinGetStudio.Views.ConfigurationFlow.DagPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    mc:Ignorable="d">
+
+    <i:Interaction.Behaviors>
+        <i:EventTriggerBehavior EventName="Loaded">
+            <i:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand}" />
+        </i:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
+
+    <Page.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+    </Page.Resources>
+
+    <Grid RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!-- Header with back button -->
+        <Grid Padding="16,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Command="{x:Bind ViewModel.BackCommand}" x:Uid="DagPage_Back">
+                    <FontIcon Glyph="&#xE72B;" FontSize="14" />
+                </Button>
+                <TextBlock x:Uid="DagPage_Title" Style="{ThemeResource SubtitleTextBlockStyle}" VerticalAlignment="Center" />
+            </StackPanel>
+        </Grid>
+
+        <!-- Error state -->
+        <InfoBar Grid.Row="1"
+                 IsOpen="{x:Bind ViewModel.HasCycleError, Mode=OneWay}"
+                 Severity="Error"
+                 x:Uid="DagPage_LayoutError"
+                 Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}"
+                 IsClosable="False"
+                 Margin="16,0" />
+
+        <!-- Empty state -->
+        <StackPanel Grid.Row="1"
+                    Visibility="{x:Bind ViewModel.IsEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="8">
+            <FontIcon Glyph="&#xE9D9;" FontSize="48" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+            <TextBlock x:Uid="DagPage_EmptyState" Style="{ThemeResource BodyTextBlockStyle}"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}" HorizontalAlignment="Center" />
+        </StackPanel>
+
+        <!-- DAG Canvas -->
+        <ScrollViewer Grid.Row="1"
+                      HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Auto"
+                      ZoomMode="Enabled"
+                      MinZoomFactor="0.3"
+                      MaxZoomFactor="3.0">
+            <Canvas x:Name="DagCanvas"
+                    Width="{x:Bind ViewModel.CanvasWidth, Mode=OneWay}"
+                    Height="{x:Bind ViewModel.CanvasHeight, Mode=OneWay}"
+                    Background="Transparent" />
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/src/WinGetStudio/Views/ConfigurationFlow/DagPage.xaml.cs
+++ b/src/WinGetStudio/Views/ConfigurationFlow/DagPage.xaml.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using WinGetStudio.Contracts.Views;
+using WinGetStudio.Models.Graph;
+using WinGetStudio.ViewModels.ConfigurationFlow;
+
+using Path = Microsoft.UI.Xaml.Shapes.Path;
+
+namespace WinGetStudio.Views.ConfigurationFlow;
+
+/// <summary>
+/// Page that renders the DAG dependency graph using a Canvas.
+/// Nodes are rendered as <see cref="DagNodeControl"/> elements and edges as Path elements.
+/// </summary>
+public sealed partial class DagPage : Page, IView<DagViewModel>
+{
+    private static readonly SolidColorBrush DefaultEdgeBrush = new(Colors.Gray);
+    private static readonly SolidColorBrush HighlightedEdgeBrush = new(Colors.Orange);
+
+    private readonly Dictionary<DagEdge, PropertyChangedEventHandler> _edgeHandlers = [];
+
+    public DagViewModel ViewModel { get; }
+
+    public DagPage()
+    {
+        ViewModel = App.GetService<DagViewModel>();
+        InitializeComponent();
+
+        ViewModel.Nodes.CollectionChanged += OnNodesCollectionChanged;
+        ViewModel.Edges.CollectionChanged += OnEdgesCollectionChanged;
+
+        Unloaded += OnUnloaded;
+    }
+
+    /// <summary>
+    /// Cleans up event subscriptions when the page is unloaded.
+    /// </summary>
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        ViewModel.Nodes.CollectionChanged -= OnNodesCollectionChanged;
+        ViewModel.Edges.CollectionChanged -= OnEdgesCollectionChanged;
+        ClearCanvasNodes();
+        ClearCanvasEdges();
+    }
+
+    private void OnNodesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            ClearCanvasNodes();
+        }
+
+        if (e.NewItems != null)
+        {
+            foreach (DagNode node in e.NewItems)
+            {
+                AddNodeToCanvas(node);
+            }
+        }
+    }
+
+    private void OnEdgesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            ClearCanvasEdges();
+        }
+
+        if (e.NewItems != null)
+        {
+            foreach (DagEdge edge in e.NewItems)
+            {
+                AddEdgeToCanvas(edge);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a <see cref="DagNodeControl"/> for the given node and positions it on the canvas.
+    /// </summary>
+    private void AddNodeToCanvas(DagNode node)
+    {
+        var control = new DagNodeControl { Node = node };
+        control.NodeTapped += OnDagNodeTapped;
+
+        Canvas.SetLeft(control, node.X);
+        Canvas.SetTop(control, node.Y);
+        Canvas.SetZIndex(control, 1);
+
+        DagCanvas.Children.Add(control);
+    }
+
+    /// <summary>
+    /// Creates Path elements for the edge line and arrowhead, and subscribes to highlight changes.
+    /// </summary>
+    private void AddEdgeToCanvas(DagEdge edge)
+    {
+        if (string.IsNullOrEmpty(edge.PathData))
+        {
+            return;
+        }
+
+        // Edge line
+        var path = new Path
+        {
+            Data = (Geometry)Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(Geometry), edge.PathData),
+            Stroke = DefaultEdgeBrush,
+            StrokeThickness = 2,
+            Tag = edge,
+        };
+
+        Canvas.SetZIndex(path, 0);
+        DagCanvas.Children.Add(path);
+
+        // Arrowhead
+        if (!string.IsNullOrEmpty(edge.ArrowHeadData))
+        {
+            var arrowPath = new Path
+            {
+                Data = (Geometry)Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(Geometry), edge.ArrowHeadData),
+                Fill = DefaultEdgeBrush,
+                Tag = edge,
+            };
+
+            Canvas.SetZIndex(arrowPath, 0);
+            DagCanvas.Children.Add(arrowPath);
+        }
+
+        // Subscribe to highlight changes with trackable handler.
+        PropertyChangedEventHandler handler = (s, e) =>
+        {
+            if (e.PropertyName == nameof(DagEdge.IsHighlighted))
+            {
+                DispatcherQueue.TryEnqueue(() => UpdateEdgeHighlight(edge));
+            }
+        };
+
+        edge.PropertyChanged += handler;
+        _edgeHandlers[edge] = handler;
+    }
+
+    /// <summary>
+    /// Updates the stroke and fill of all Path elements associated with the given edge.
+    /// </summary>
+    private void UpdateEdgeHighlight(DagEdge edge)
+    {
+        var brush = edge.IsHighlighted ? HighlightedEdgeBrush : DefaultEdgeBrush;
+        var thickness = edge.IsHighlighted ? 3.0 : 2.0;
+
+        foreach (var child in DagCanvas.Children)
+        {
+            if (child is Path path && path.Tag == edge)
+            {
+                path.Stroke = brush;
+                path.StrokeThickness = thickness;
+                if (path.Fill != null)
+                {
+                    path.Fill = brush;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes all node controls from the canvas and unsubscribes their event handlers.
+    /// </summary>
+    private void ClearCanvasNodes()
+    {
+        var toRemove = DagCanvas.Children.OfType<DagNodeControl>().ToList();
+        foreach (var control in toRemove)
+        {
+            control.NodeTapped -= OnDagNodeTapped;
+            control.Node = null!;
+            DagCanvas.Children.Remove(control);
+        }
+    }
+
+    /// <summary>
+    /// Removes all edge Path elements from the canvas and unsubscribes PropertyChanged handlers.
+    /// </summary>
+    private void ClearCanvasEdges()
+    {
+        foreach (var (edge, handler) in _edgeHandlers)
+        {
+            edge.PropertyChanged -= handler;
+        }
+
+        _edgeHandlers.Clear();
+
+        var toRemove = DagCanvas.Children.OfType<Path>().ToList();
+        foreach (var path in toRemove)
+        {
+            DagCanvas.Children.Remove(path);
+        }
+    }
+
+    private void OnDagNodeTapped(object? sender, DagNode node)
+    {
+        ViewModel.OnNodeSelected(node);
+    }
+}

--- a/src/WinGetStudio/Views/ConfigurationFlow/PreviewFilePage.xaml
+++ b/src/WinGetStudio/Views/ConfigurationFlow/PreviewFilePage.xaml
@@ -153,6 +153,12 @@
                     </AppBarButton.Flyout>
                 </AppBarButton>
                 <AppBarSeparator />
+                <AppBarButton x:Uid="PreviewPage_VisualizeDependencies" Command="{x:Bind ViewModel.NavigateToDagCommand}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE9D9;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarSeparator />
                 <AppBarButton Icon="Save" x:Uid="PreviewPage_Save" Command="{x:Bind ViewModel.PreviewSet.SaveConfigurationCommand, Mode=OneWay}" />
                 <AppBarButton Icon="Save" x:Uid="PreviewPage_SaveAs" Click="SaveConfigurationFileAs" IsEnabled="{x:Bind ViewModel.PreviewSet.CanSaveConfigurationAs, Mode=OneWay}" />
             </CommandBar>

--- a/src/WinGetStudio/WinGetStudio.csproj
+++ b/src/WinGetStudio/WinGetStudio.csproj
@@ -53,6 +53,8 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" />
     <PackageReference Include="WinUIEx" />
+    <PackageReference Include="AutomaticGraphLayout" />
+    <PackageReference Include="AutomaticGraphLayout.Drawing" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Links -->
[ms-cla]: https://cla.opensource.microsoft.com
<!-- End of Links -->

## 📖 Description
Adds a directed acyclic graph (DAG) visualization to WinGet Studio. The layout is created using the [Microsoft Automatic Graph Layout](https://github.com/microsoft/automatic-graph-layout) package, then visualized on a WinUI canvas.

## 🔗 References and Related Issues
Resolves #197 

## 🔍 How to Test
To test, simply load a winget config file, then click the "Visualize" button.
Tests were also added to validate that the layout engine works as expected.

## ✅ Checklist
- [ ] Have you signed the [Contributor License Agreement][ms-cla]?
   - No, I work here.
- [X] Is there a linked Issue?
- [ ] Documentation updated?
   - unnecessary(?)
