### PR TITLE
Improve policy bot rules: stale flow, auth, close cleanup, Template tags

### DIFF
--- a/.github/policies/labelAdded.noRecentActivity.yml
+++ b/.github/policies/labelAdded.noRecentActivity.yml
@@ -1,0 +1,46 @@
+id: labelAdded.noRecentActivity
+name: GitOps.PullRequestIssueManagement
+description: Post warning replies when No-Recent-Activity is added
+owner: 
+resource: repository
+disabled: false
+where: 
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: >-
+        When the label "No-Recent-Activity" is added to an issue
+        * Add a reply notifying the author of pending closure
+      if:
+      - payloadType: Issues
+      - labelAdded:
+          label: No-Recent-Activity
+      then:
+      - addReply:
+          reply: >-
+            This issue has been automatically marked as stale because it has been marked as
+            requiring author feedback but has not had any activity for **5 days**. It will be
+            closed if no further activity occurs **within 5 days of this comment**.
+
+
+            Template: msftbot/noRecentActivity
+      triggerOnOwnActions: true
+    - description: >-
+        When the label "No-Recent-Activity" is added to a PR
+        * Add a reply notifying the author of pending closure
+      if:
+      - payloadType: Pull_Request
+      - labelAdded:
+          label: No-Recent-Activity
+      then:
+      - addReply:
+          reply: >-
+            This pull request has been automatically marked as stale because it has been marked as
+            requiring author feedback but has not had any activity for **5 days**. It will be
+            closed if no further activity occurs **within 5 days of this comment**.
+
+
+            Template: msftbot/noRecentActivity
+      triggerOnOwnActions: true
+onFailure: 
+onSuccess: 

--- a/.github/policies/labelManagement.issueClosed.yml
+++ b/.github/policies/labelManagement.issueClosed.yml
@@ -1,0 +1,26 @@
+id: labelManagement.issueClosed
+name: GitOps.PullRequestIssueManagement
+description: Handlers when an issue or pull request gets closed
+owner: 
+resource: repository
+disabled: false
+where: 
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: Remove labels when an issue or pull request is closed
+      if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - isAction:
+          action: Closed
+      then:
+      - removeLabel:
+          label: Needs-Triage
+      - removeLabel:
+          label: Needs-Attention
+      - removeLabel:
+          label: Needs-Author-Feedback
+onFailure: 
+onSuccess: 

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -36,7 +36,9 @@ configuration:
           label: No-Recent-Activity
     - description: Clean email replies on every comment
       if:
-      - payloadType: Issue_Comment
+      - or:
+        - payloadType: Issue_Comment
+        - payloadType: Pull_Request_Review_Comment
       then:
       - cleanEmailReply
     - description: Add In-PR when an issue has a linked PR that will close it

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -19,20 +19,23 @@ configuration:
       if:
       - payloadType: Issue_Comment
       - commentContains:
-          pattern: '(\/)?[Dd]up(licate|e)?(\s+of)?\s+(\#[\d]+|https)'
+          pattern: '(?in)(\/(dup|dupe)|Duplicate)(\s+of)?\s+(\#[\d]+|https)'
           isRegex: True
       - or:
-        - activitySenderHasAssociation:
-            association: Owner
-        - activitySenderHasAssociation:
-            association: Member
+        - activitySenderHasPermission:
+            permission: Admin
+        - activitySenderHasPermission:
+            permission: Write
       then:
       - addReply:
-          reply: >- 
-              We've identified this as a duplicate of another one that already exists. This 
-              specific instance is being closed in favor of tracking the concern over on the the 
-              linked issue. Please add your 👍 to the other issue to raise its priority. Thanks 
+          reply: >-
+              We've identified this as a duplicate of another one that already exists. This
+              specific instance is being closed in favor of tracking the concern over on the
+              linked issue. Please add your 👍 to the other issue to raise its priority. Thanks
               for your report!
+
+
+              Template: msftbot/duplicate/closed
       - closeIssue
       - removeLabel:
           label: Needs-Attention
@@ -46,13 +49,13 @@ configuration:
       if:
       - payloadType: Issue_Comment
       - commentContains:
-          pattern: '\/needinfo'
+          pattern: '(?in)\/needinfo'
           isRegex: True
       - or:
-        - activitySenderHasAssociation:
-            association: Owner
-        - activitySenderHasAssociation:
-            association: Member
+        - activitySenderHasPermission:
+            permission: Admin
+        - activitySenderHasPermission:
+            permission: Write
       then:
       - removeLabel:
           label: Needs-Attention
@@ -66,13 +69,13 @@ configuration:
       if:
       - payloadType: Issue_Comment
       - commentContains:
-          pattern: '\/loc\b'
+          pattern: '(?in)\/loc\b'
           isRegex: True
       - or:
-        - activitySenderHasAssociation:
-            association: Owner
-        - activitySenderHasAssociation:
-            association: Member
+        - activitySenderHasPermission:
+            permission: Admin
+        - activitySenderHasPermission:
+            permission: Write
       then:
       - removeLabel:
           label: Needs-Triage
@@ -82,5 +85,8 @@ configuration:
           reply: >-
               Hi! Thanks for making us aware of the problem. We raised the issue with our internal 
               localization team.
+
+
+              Template: msftbot/localization
 onFailure: 
 onSuccess: 

--- a/.github/policies/scheduledSearch.closeNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.closeNoRecentActivity.yml
@@ -30,5 +30,27 @@ configuration:
           days: 5
       actions:
       - closeIssue
+    - description: >-
+          Search for PRs where -
+          * Pull Request is Open
+          * Pull Request has the label Needs-Author-Feedback
+          * Pull Request has the label No-Recent-Activity
+          * Has not had activity in the last 5 days
+          Then -
+          * Close the PR
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - hasLabel:
+          label: No-Recent-Activity
+      - noActivitySince:
+          days: 5
+      actions:
+      - closeIssue
 onFailure: 
 onSuccess: 

--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -31,7 +31,28 @@ configuration:
       actions:
       - addLabel:
           label: No-Recent-Activity
-      - addReply:
-          reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **5 days**. It will be closed if no further activity occurs **within 5 days of this comment**.
+    - description: >-
+          Search for PRs where -
+          * Pull Request is Open
+          * Pull Request has the label Needs-Author-Feedback
+          * Pull Request does not have the label No-Recent-Activity
+          * Has not had activity in the last 5 days
+          Then -
+          * Mark the PR as No-Recent-Activity
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - noActivitySince:
+          days: 5
+      - isNotLabeledWith:
+          label: No-Recent-Activity
+      actions:
+      - addLabel:
+          label: No-Recent-Activity
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
## 📖 Description
Created with GitHub Copilot assistance.

Improve the policy bot rule set by splitting stale handling between scheduled search and label-added flows, tightening authorization checks, simplifying close cleanup, applying Template: tags to bot replies, and fixing related casing and reply handling across the six changed policy files.

## 🔗 References
Resolves #205

## 🔍 Validation
- Reviewed the policy changes in:
  - .github/policies/labelAdded.noRecentActivity.yml
  - .github/policies/labelManagement.issueClosed.yml
  - .github/policies/labelManagement.issueUpdated.yml
  - .github/policies/moderatorTriggers.yml
  - .github/policies/scheduledSearch.closeNoRecentActivity.yml
  - .github/policies/scheduledSearch.markNoRecentActivity.yml

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task