### PR TITLE
Add .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# WinGet Studio Development Guide
+
+## Project Overview
+
+**WinGet Studio** (experimental) is a Windows app for authoring and testing WinGet Configuration files (DSC-based Configuration as Code) without needing deep DSC expertise up front. It lets users create/edit configuration files and run "get", "set", and "test" against **installed** DSC resources.
+
+- **`src/WinGetStudio`** - Main WinUI application (UI, views, view models)
+- **`src/WinGetStudio.CLI`** - Command-line surface
+- **`src/WinGetStudio.Core`** - Shared UI-adjacent helpers (`FileDialog`, `Helpers`)
+- **`src/services/WinGetStudio.Services.Core`** - Core service abstractions
+- **`src/services/WinGetStudio.Services.DesiredStateConfiguration`** / **`...Explorer`** - DSC resource discovery, invocation, and exploration services
+- **`src/services/WinGetStudio.Services.Localization`** - Localization service
+- **`src/services/WinGetStudio.Services.Logging`** - Logging service
+- **`src/services/WinGetStudio.Services.Settings`** - App settings persistence
+- **`src/services/WinGetStudio.Services.Telemetry`** - Telemetry service
+- **`src/services/WinGetStudio.Services.VisualFeedback`** - UI feedback/animation helpers
+- **`src/WinGetStudio.Tests.MSTest`** - MSTest-based unit tests
+- **`docs/`** - User-facing documentation (getting started, DSC concepts, migration, CLI reference)
+
+## Building, Testing, and Running
+
+### Initial Setup
+
+Apply the WinGet configuration file to provision your dev environment:
+
+```powershell
+winget configure '.\.config\configuration.winget'
+```
+
+### Building
+
+- **Visual Studio**: open `src/WinGetStudio.sln` and build.
+- **Script**: run `.\Build.ps1` from a PowerShell terminal (certificate signing requires admin privileges).
+
+### Testing
+
+Run tests via Visual Studio Test Explorer against `WinGetStudio.Tests.MSTest`, or `dotnet test` from the command line.
+
+## Architecture & Key Patterns
+
+- **Service-oriented structure**: cross-cutting concerns (DSC operations, settings, telemetry, logging, localization) are implemented as injectable services under `src/services/`, consumed by the WinUI app and CLI.
+- **DSC v3 vs 0.2.0 format**: the app must handle both legacy WinGet Configuration (0.2.0) and Microsoft DSC v3.x configuration formats — see `docs/concepts/configuration-versions.md` and `docs/how-to/migrate-configuration-to-dsc3.md` before changing config parsing/serialization.
+- **Resource discovery**: `WinGetStudio.Services.DesiredStateConfiguration.Explorer` surfaces installed DSC resources (including PowerShell Gallery-sourced ones) for the authoring UI.
+
+## Naming Conventions
+
+- Namespaces follow `WinGetStudio.<Area>` (e.g., `WinGetStudio.Services.DesiredStateConfiguration`).
+- Shared build/versioning settings live in `Directory.Build.props`, `Directory.Packages.props`, and `ToolingVersions.props` at `src/` root — prefer updating these over per-project overrides.
+
+## Contributing
+
+- Review `CONTRIBUTING.md` (root) for workflow and CLA requirements.
+- This project is **experimental** — expect API/format churn; check `docs/changelog.md` before assuming stability of a given surface.
+- CI runs via Azure Pipelines.
+
+## Privacy & Telemetry
+
+The application logs basic diagnostic telemetry. See `docs/` and `PRIVACY.md` for details on what is collected.


### PR DESCRIPTION
## 📖 Description

Adds .github/copilot-instructions.md to give GitHub Copilot (and other AI coding agents) accurate context on this repo's structure (WinUI app, CLI, service layer), build/test/run steps, and the DSC v3 vs. 0.2.0 configuration format distinction.

Created with GitHub Copilot's assistance.

## 🔗 References

Closes #214

## 🔍 Validation

Documentation-only change; no build/test impact. Content reviewed manually against the current repo layout and README.md.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task
